### PR TITLE
Fixed a bug dealing with the ID property on Traits and Values. A non-global RegEx.replace() was to blame.

### DIFF
--- a/src/profiles/v2/index.js
+++ b/src/profiles/v2/index.js
@@ -34,7 +34,7 @@ class PersonalityProfile {
         facets: t.children.map(function(f) {
           return {
             //id: f.id,
-            id: f.id.replace('_', '-').replace(' ', '-'),
+            id: f.id.replace(/_/g, '-').replace(/ /g, '-'),
             name: f.name,
             category: f.category,
             score: f.percentage
@@ -59,7 +59,7 @@ class PersonalityProfile {
     return this._values.map(function(v) {
       return {
         //id: v.id,
-        id: v.id.replace('_', '-').replace(' ', '-'),
+        id: v.id.replace(/_/g, '-').replace(/ /g, '-'),
         name: v.name,
         category: v.category,
         score: v.percentage


### PR DESCRIPTION
Fixed a bug dealing with the ID property on Traits and Values within /src/profiles/v2/index.js.  The replace routine had failed to turn 'Openess to Change' into 'Openess-to-Change'.  Instead it was doing a non-global replace and so the ID was incorrectly turned into 'Openess-to Change' (with only 1 dash).

I'm not sure how this codebase could have worked for anyone else.  Maybe everyone else has moved onto v3? 